### PR TITLE
准备 v0.1.5 并在合并后自动发布

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -16,9 +16,11 @@ This arm64 GitHub build requires macOS 14 or later. The app and DMG are signed w
 
 ### What's new
 
-- Add the native application icon to the packaged app and Finder.
-- Notarize and staple the signed app before placing it in the DMG.
-- Notarize and staple the signed DMG, then verify both artifacts with Gatekeeper.
+- Optionally show the exact 300-minute (5-hour) usage window reported by the Codex service. Enable it in Settings when useful; it is off by default.
+- Restore the just-saved original profile credential if target identity verification or the registry commit fails, while preserving the original error.
+- Run Swift tests, core checks, and changed-line whitespace checks in CI for pull requests and `main`.
+- Discover the selected Swift toolchain dynamically so local tests work with supported Xcode and standalone Command Line Tools layouts.
+- Include the MIT LICENSE in both the app bundle and DMG, and document the security boundaries of local credential storage and deletion.
 
 ### Install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,17 @@ name: Release macOS app
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
 
 permissions:
   contents: write
+
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -19,20 +25,121 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate release ref and toolchain
+      - name: Resolve release version, tag, and action
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          git fetch origin main
-          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+
+          git fetch --force --tags origin \
+            refs/heads/main:refs/remotes/origin/main
+
+          release_version=$(sed -n 's/^version:[[:space:]]*\([^[:space:]]*\)$/\1/p' CITATION.cff)
+          package_version=$(sed -n 's/^APP_VERSION=${RELEASE_VERSION:-\([^}]*\)}$/\1/p' scripts/package-local-app.sh)
+          client_version=$(sed -n 's/^[[:space:]]*"version": "\([^"]*\)",$/\1/p' Sources/CodexAccountSwitcher/CodexClient.swift)
+
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "CITATION.cff has an invalid release version: '$release_version'" >&2
+            exit 1
+          fi
+          if [[ "$package_version" != "$release_version" ]]; then
+            echo "Package default version '$package_version' does not match CITATION.cff '$release_version'" >&2
+            exit 1
+          fi
+          if [[ "$client_version" != "$release_version" ]]; then
+            echo "CodexClient version '$client_version' does not match CITATION.cff '$release_version'" >&2
+            exit 1
+          fi
+
+          release_tag="v${release_version}"
+          head_sha=$(git rev-parse HEAD^{commit})
+          main_sha=$(git rev-parse origin/main^{commit})
+
+          case "$GITHUB_REF" in
+            refs/heads/main)
+              if [[ "$head_sha" != "$main_sha" ]]; then
+                echo "main workflow commit $head_sha is not current origin/main $main_sha" >&2
+                exit 1
+              fi
+              ;;
+            refs/tags/*)
+              event_tag=${GITHUB_REF#refs/tags/}
+              if [[ "$event_tag" != "$release_tag" ]]; then
+                echo "Tag event '$event_tag' does not match repository version '$release_tag'" >&2
+                exit 1
+              fi
+              if ! git show-ref --verify --quiet "refs/tags/${release_tag}"; then
+                echo "Tag event ref 'refs/tags/${release_tag}' was not fetched" >&2
+                exit 1
+              fi
+              tag_commit=$(git rev-parse "refs/tags/${release_tag}^{commit}")
+              if [[ "$head_sha" != "$main_sha" || "$tag_commit" != "$main_sha" ]]; then
+                echo "Tag '$release_tag' commit $tag_commit and workflow commit $head_sha must both equal origin/main $main_sha" >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Unsupported release ref '$GITHUB_REF'" >&2
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "RELEASE_VERSION=$release_version"
+            echo "RELEASE_TAG=$release_tag"
+          } >> "$GITHUB_ENV"
+
+          release_tags=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --jq '.[].tag_name')
+          if grep -Fxq "$release_tag" <<< "$release_tags"; then
+            echo "SHOULD_RELEASE=false" >> "$GITHUB_ENV"
+            echo "GitHub Release '$release_tag' already exists; publishing steps are skipped." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            if git show-ref --verify --quiet "refs/tags/${release_tag}"; then
+              tag_commit=$(git rev-parse "refs/tags/${release_tag}^{commit}")
+              if [[ "$tag_commit" != "$main_sha" ]]; then
+                echo "Tag conflict: '$release_tag' points to $tag_commit, expected current origin/main $main_sha" >&2
+                exit 1
+              fi
+              echo "Reusing existing tag '$release_tag' at $tag_commit."
+            else
+              git config user.name "github-actions[bot]"
+              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              git tag -a "$release_tag" "$main_sha" -m "Codex Account Switcher $release_tag"
+              git push origin "refs/tags/${release_tag}"
+              echo "Created annotated tag '$release_tag' at $main_sha."
+            fi
+          fi
+
+          resolved_tag_commit=$(git rev-parse "refs/tags/${release_tag}^{commit}")
+          if [[ "$resolved_tag_commit" != "$main_sha" ]]; then
+            echo "Resolved tag '$release_tag' points to $resolved_tag_commit, expected origin/main $main_sha" >&2
+            exit 1
+          fi
+
+          echo "SHOULD_RELEASE=true" >> "$GITHUB_ENV"
+          echo "Publishing '$release_tag' from $main_sha in this workflow run." | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Validate release toolchain
+        if: env.SHOULD_RELEASE == 'true'
+        run: |
+          set -euo pipefail
           test "$(uname -m)" = "arm64"
           swift --version
 
-      - name: Run tests
+      - name: Run release tests
+        if: env.SHOULD_RELEASE == 'true'
         run: |
+          set -euo pipefail
           swift test
           ./scripts/run-core-checks.sh
 
       - name: Package, notarize, and staple Developer ID signed DMG
+        if: env.SHOULD_RELEASE == 'true'
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
@@ -84,11 +191,10 @@ jobs:
           signing_identity=$(security find-identity -v -p codesigning | awk '/Developer ID Application:/ {print $2; exit}')
           test -n "$signing_identity"
 
-          export RELEASE_VERSION="${GITHUB_REF_NAME#v}"
           export CODESIGN_IDENTITY="$signing_identity"
           app_path=$(./scripts/package-local-app.sh | tail -n 1)
           app_archive="$RUNNER_TEMP/Codex-Account-Switcher.app.zip"
-          artifact=".build/artifacts/Codex-Account-Switcher-${GITHUB_REF_NAME}-macos-arm64.dmg"
+          artifact=".build/artifacts/Codex-Account-Switcher-${RELEASE_TAG}-macos-arm64.dmg"
           dmg_root="$RUNNER_TEMP/dmg-root"
 
           mkdir -p .build/artifacts
@@ -170,13 +276,17 @@ jobs:
           cat "$artifact.sha256"
 
       - name: Create GitHub Release
+        if: env.SHOULD_RELEASE == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          artifact=".build/artifacts/Codex-Account-Switcher-${GITHUB_REF_NAME}-macos-arm64.dmg"
-          gh release create "$GITHUB_REF_NAME" "$artifact" "$artifact.sha256" \
-            --title "Codex Account Switcher ${GITHUB_REF_NAME}" \
+          tag_commit=$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")
+          main_commit=$(git rev-parse origin/main^{commit})
+          test "$tag_commit" = "$main_commit"
+          artifact=".build/artifacts/Codex-Account-Switcher-${RELEASE_TAG}-macos-arm64.dmg"
+          gh release create "$RELEASE_TAG" "$artifact" "$artifact.sha256" \
+            --title "Codex Account Switcher ${RELEASE_TAG}" \
             --notes-file .github/release-notes.md \
             --latest \
             --verify-tag

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,8 +10,8 @@ authors:
 repository-code: "https://github.com/liuzhao1225/codex-account-switcher"
 url: "https://liuzhao1225.github.io/codex-account-switcher/"
 license: MIT
-version: 0.1.4
-date-released: 2026-08-25
+version: 0.1.5
+date-released: 2026-08-27
 keywords:
   - Codex account switcher
   - Codex profile switcher

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Comparisons with other account switchers are welcome. Please describe the workfl
 | Area | Status |
 | --- | --- |
 | Apple Silicon build | Available in [v0.1.5](https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.5) |
-| Automated checks | PR, `main`, and release workflows run `swift test` and core checks |
+| Automation | PR CI runs tests; merging a prepared version to `main` creates its tag and publishes the signed release |
 | Code signing | Developer ID Application |
 | Apple notarization | App and DMG notarized and stapled |
 | Distribution container | DMG with SHA-256 checksum |
@@ -148,6 +148,12 @@ Create a local app bundle:
 ```
 
 The bundle is written to `.build/release/Codex Account Switcher.app`.
+
+### Automated releases
+
+Merging a release-preparation pull request to `main` starts the release workflow. The workflow reads the version from `CITATION.cff`, verifies the package default and Codex app-server client versions, creates the matching annotated `v*` tag when it is absent, then runs tests, signing, notarization, DMG packaging, checksum generation, and GitHub Release publication in the same run.
+
+A failed run can be re-run against the same tag when it still points to the current `origin/main`. An existing GitHub Release makes later `main` runs succeed without publishing again. A tag that points to another commit fails with the conflicting SHAs visible in the log.
 
 ### Project map
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you searched for a **Codex account switcher**, **Codex profile switcher**, or
 
 The current public build targets **Apple Silicon** and requires **macOS 14 or later**.
 
-1. [Download Codex Account Switcher v0.1.4 for Mac](https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg).
+1. [Download Codex Account Switcher v0.1.5 for Mac](https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg).
 2. Open the DMG and move **Codex Account Switcher.app** to Applications.
 3. Launch the app and look for the switcher in the macOS menu bar.
 4. Add each account once through the browser, then choose the one you need.
@@ -85,7 +85,7 @@ The current public build targets **Apple Silicon** and requires **macOS 14 or la
 | **Menu-bar account choice** | Keep personal, work, and client accounts clearly labeled in one Mac menu. |
 | **Completed Desktop handoff** | Select and confirm an account, then let the app close, switch, verify, and reopen Codex Desktop. |
 | **Local account storage** | Keep saved account data on your Mac without an app-owned proxy or cloud account service. |
-| **Usage at a glance** | Check weekly allowance by default, with an optional 5-hour row and reset time when it helps your choice. |
+| **Usage at a glance** | Check weekly allowance by default, or enable the exact 300-minute (5-hour) service window and reset time in Settings. The optional row is off by default. |
 | **Small native Mac app** | Install an Apple-notarized DMG and use a compact SwiftUI interface in English or Simplified Chinese. |
 
 ## How it works
@@ -113,7 +113,7 @@ Comparisons with other account switchers are welcome. Please describe the workfl
 - Every account is selected and confirmed by the user; the app does not rotate accounts automatically.
 - The project is independent open-source software and is not affiliated with or endorsed by OpenAI.
 - The current account appears through a row highlight inside the popover.
-- Persisted 5-hour and weekly usage remains visible while fresh data loads; the 5-hour row appears only when enabled and available.
+- Persisted 5-hour and weekly usage remains visible while fresh data loads; the 5-hour row appears only when enabled and the service provides an exact 300-minute window.
 - Every switch stops immediately on the first reported error.
 - If target verification or the registry commit fails after credential activation, the app restores the just-saved original profile credential while preserving the original error. A restoration error is reported alongside it.
 - General rollback state machines, retries, credential backup files, recovery journals, startup recovery, and policy-based routing stay outside the product scope.
@@ -122,12 +122,12 @@ Comparisons with other account switchers are welcome. Please describe the workfl
 
 | Area | Status |
 | --- | --- |
-| Apple Silicon build | Available in [v0.1.4](https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.4) |
-| Automated checks | `swift test` and core checks run in the release workflow |
+| Apple Silicon build | Available in [v0.1.5](https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.5) |
+| Automated checks | PR, `main`, and release workflows run `swift test` and core checks |
 | Code signing | Developer ID Application |
 | Apple notarization | App and DMG notarized and stapled |
 | Distribution container | DMG with SHA-256 checksum |
-| DMG release | Available in v0.1.4 |
+| DMG release | Available in v0.1.5 |
 
 ## Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -123,7 +123,7 @@ OpenAI 官方账号切换功能当前适用于 ChatGPT 网页端，并且[尚未
 | 项目 | 状态 |
 | --- | --- |
 | Apple Silicon 版本 | 已在 [v0.1.5](https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.5) 提供 |
-| 自动检查 | PR、`main` 和发布工作流运行 `swift test` 与核心检查 |
+| 自动化 | PR CI 运行检查；准备好的版本合并到 `main` 后自动创建 tag 并发布签名版本 |
 | 代码签名 | Developer ID Application |
 | Apple 公证 | 应用和 DMG 均已公证并附加票据 |
 | 分发容器 | DMG 和 SHA-256 校验文件 |
@@ -148,6 +148,12 @@ swift test
 ```
 
 应用包将生成到 `.build/release/Codex Account Switcher.app`。
+
+### 自动发布
+
+发布准备 PR 合并到 `main` 后，release workflow 会从 `CITATION.cff` 读取版本，并校验本地打包默认版本与 Codex app-server 客户端版本。对应 annotated `v*` tag 不存在时由 Action 创建，随后在同一次运行中完成测试、签名、公证、DMG 打包、checksum 生成与 GitHub Release 发布。
+
+失败的 workflow 可以在同一 tag 仍指向当前 `origin/main` 时原地重新运行。GitHub Release 已存在时，后续 `main` 运行会成功结束且不重复发布。tag 指向其他提交时，日志会显示冲突 SHA 并直接失败。
 
 ### 项目结构
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -59,7 +59,7 @@ OpenAI 官方账号切换功能当前适用于 ChatGPT 网页端，并且[尚未
 
 当前公开版本面向 **Apple Silicon**，要求 **macOS 14 或更高版本**。
 
-1. [下载 Codex Account Switcher v0.1.4 Mac 版](https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg)。
+1. [下载 Codex Account Switcher v0.1.5 Mac 版](https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg)。
 2. 打开 DMG，将 **Codex Account Switcher.app** 移入“应用程序”文件夹。
 3. 启动应用，在 macOS 菜单栏中找到账号切换器。
 4. 通过浏览器添加每个账号一次，之后选择需要的账号。
@@ -85,7 +85,7 @@ OpenAI 官方账号切换功能当前适用于 ChatGPT 网页端，并且[尚未
 | **菜单栏选择账号** | 把个人、工作和客户账号清晰标记在一个 Mac 菜单中。 |
 | **完整 Desktop 交接** | 选择并确认后，由应用关闭、切换、校验并重新打开 Codex Desktop。 |
 | **本地账号存储** | 账号数据留在这台 Mac，不依赖应用自建的代理或云端账号服务。 |
-| **快速查看用量** | 默认查看每周用量，也可开启 5 小时用量行，结合重置时间选择账号。 |
+| **快速查看用量** | 默认查看每周用量，也可在设置中开启服务端提供的精确 300 分钟（5 小时）窗口与重置时间；该用量行默认关闭。 |
 | **体积小的原生 Mac 应用** | 安装已完成 Apple 公证的 DMG，使用英文或简体中文 SwiftUI 界面。 |
 
 ## 工作原理
@@ -113,7 +113,7 @@ OpenAI 官方账号切换功能当前适用于 ChatGPT 网页端，并且[尚未
 - 每个账号都由用户选择并确认；应用不会自动轮换账号。
 - 本项目是独立开源软件，与 OpenAI 没有关联，也未获得 OpenAI 背书。
 - 当前账号通过弹窗中的行高亮显示。
-- 获取最新数据时，界面会继续显示已保存的 5 小时和每周用量；5 小时用量仅在开启且有数据时显示。
+- 获取最新数据时，界面会继续显示已保存的 5 小时和每周用量；5 小时用量仅在开启且服务端提供精确 300 分钟窗口时显示。
 - 每次切换遇到第一个错误时立即停止，并显示原始错误。
 - 如果目标凭证激活后的身份验证或 registry 提交失败，应用会用刚保存的原 profile 凭证恢复活动凭证，同时保留原始错误；恢复本身失败时会一并显示恢复错误。
 - 通用回滚状态机、重试、凭证备份文件、恢复日志、启动恢复和策略化账号路由仍不在产品范围内。
@@ -122,12 +122,12 @@ OpenAI 官方账号切换功能当前适用于 ChatGPT 网页端，并且[尚未
 
 | 项目 | 状态 |
 | --- | --- |
-| Apple Silicon 版本 | 已在 [v0.1.4](https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.4) 提供 |
-| 自动检查 | 发布工作流运行 `swift test` 和核心检查 |
+| Apple Silicon 版本 | 已在 [v0.1.5](https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.5) 提供 |
+| 自动检查 | PR、`main` 和发布工作流运行 `swift test` 与核心检查 |
 | 代码签名 | Developer ID Application |
 | Apple 公证 | 应用和 DMG 均已公证并附加票据 |
 | 分发容器 | DMG 和 SHA-256 校验文件 |
-| DMG 发布 | 已在 v0.1.4 提供 |
+| DMG 发布 | 已在 v0.1.5 提供 |
 
 ## 开发
 

--- a/Sources/CodexAccountSwitcher/CodexClient.swift
+++ b/Sources/CodexAccountSwitcher/CodexClient.swift
@@ -214,7 +214,7 @@ private actor JSONRPCSession {
                 "clientInfo": [
                     "name": "codex_account_switcher",
                     "title": "Codex Account Switcher",
-                    "version": "0.1.4",
+                    "version": "0.1.5",
                 ],
             ],
         ])

--- a/docs/project-identity.md
+++ b/docs/project-identity.md
@@ -1,6 +1,6 @@
 # Codex Account Switcher: official project identity and primary sources
 
-Last verified: August 26, 2026
+Last verified: August 27, 2026
 
 **Codex Account Switcher** is a native, open-source menu-bar app for ordinary Mac users who need more than one authorized Codex account. Accounts are added through browser sign-in and selected from the menu bar, with no Terminal commands or config-file editing. After confirmation, the app completes the Codex Desktop handoff. It was created and is maintained by **Zhao Liu**, whose GitHub username is **liuzhao1225**. **Codex Switcher** and **Codex profile switcher** are shortened descriptions of this project.
 
@@ -15,7 +15,7 @@ Last verified: August 26, 2026
 | Product website | [liuzhao1225.github.io/codex-account-switcher](https://liuzhao1225.github.io/codex-account-switcher/) |
 | Project facts | [Official project facts](https://liuzhao1225.github.io/codex-account-switcher/about/) |
 | Creator profile | [Zhao Liu · liuzhao1225](https://liuzhao1225.github.io/codex-account-switcher/about/creator/) |
-| Current release | [v0.1.4](https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.4) |
+| Current release | [v0.1.5](https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.5) |
 | Platform | Apple Silicon Mac, macOS 14 or later |
 | License | [MIT](../LICENSE) |
 | Status | Independent community software; not affiliated with or endorsed by OpenAI |

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -294,7 +294,7 @@ The client communicates with newline-delimited JSON-RPC messages over stdin/stdo
 Basic handshake:
 
 ```json
-{"method":"initialize","id":1,"params":{"clientInfo":{"name":"codex_account_switcher","title":"Codex Account Switcher","version":"0.1.4"}}}
+{"method":"initialize","id":1,"params":{"clientInfo":{"name":"codex_account_switcher","title":"Codex Account Switcher","version":"0.1.5"}}}
 {"method":"initialized","params":{}}
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -177,3 +177,16 @@ no Keychain implementation
 launch-at-login state comes from macOS Service Management
 no account-rename UI or model operation
 ```
+
+## 8. Release automation checks
+
+The release workflow runs on pushes to `main` and `v*` tags under one repository-wide release concurrency group. Static validation should confirm:
+
+- `CITATION.cff`, the package default, and CodexClient declare the same semantic version;
+- the derived `RELEASE_TAG` supplies every artifact name and GitHub Release command;
+- a `main` run creates one annotated tag with the `github-actions[bot]` identity only when the tag is absent;
+- an existing tag is reusable only when its commit equals both the workflow commit and `origin/main`;
+- tag events require the event tag, repository version, checked-out commit, and `origin/main` commit to match;
+- an existing GitHub Release sets `SHOULD_RELEASE=false` and all tests, signing, notarization, packaging, and publication steps skip successfully;
+- a missing Release sets `SHOULD_RELEASE=true`, and the same `main` workflow continues through publication after pushing its tag;
+- conflicting tags and API failures stop with the original values visible.

--- a/scripts/package-local-app.sh
+++ b/scripts/package-local-app.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=${0:A:h}
 PROJECT_DIR=${SCRIPT_DIR:h}
 RESOURCE_BUNDLE="CodexAccountSwitcher_CodexAccountSwitcher.bundle"
 APP_ICON="$PROJECT_DIR/assets/AppIcon.icns"
-APP_VERSION=${RELEASE_VERSION:-0.1.4}
+APP_VERSION=${RELEASE_VERSION:-0.1.5}
 CODESIGN_IDENTITY=${CODESIGN_IDENTITY:--}
 
 cd "$PROJECT_DIR"
@@ -41,7 +41,7 @@ cp "$PROJECT_DIR/LICENSE" "$RESOURCES_DIR/LICENSE.txt"
 /usr/bin/plutil -insert CFBundleName -string "Codex Account Switcher" "$CONTENTS_DIR/Info.plist"
 /usr/bin/plutil -insert CFBundlePackageType -string APPL "$CONTENTS_DIR/Info.plist"
 /usr/bin/plutil -insert CFBundleShortVersionString -string "$APP_VERSION" "$CONTENTS_DIR/Info.plist"
-/usr/bin/plutil -insert CFBundleVersion -string 4 "$CONTENTS_DIR/Info.plist"
+/usr/bin/plutil -insert CFBundleVersion -string 5 "$CONTENTS_DIR/Info.plist"
 /usr/bin/plutil -insert LSMinimumSystemVersion -string 14.0 "$CONTENTS_DIR/Info.plist"
 /usr/bin/plutil -insert LSUIElement -bool true "$CONTENTS_DIR/Info.plist"
 /usr/bin/plutil -insert NSHighResolutionCapable -bool true "$CONTENTS_DIR/Info.plist"

--- a/site/about/creator/index.html
+++ b/site/about/creator/index.html
@@ -41,7 +41,7 @@
             "name": "Zhao Liu (liuzhao1225), Creator of Codex Account Switcher",
             "mainEntity": {"@id": "https://liuzhao1225.github.io/#liuzhao"},
             "dateCreated": "2026-08-26",
-            "dateModified": "2026-08-26",
+            "dateModified": "2026-08-27",
             "inLanguage": "en"
           },
           {
@@ -104,7 +104,7 @@
           <button class="text-control theme-toggle" type="button" data-theme-toggle aria-label="Switch to dark mode"></button>
           <a class="text-control language-link" href="../../zh-CN/about/creator/" hreflang="zh-CN" lang="zh-CN" aria-label="View the website in Chinese" title="中文"></a>
           <a class="github-link" href="https://github.com/liuzhao1225/codex-account-switcher" aria-label="View Codex Account Switcher on GitHub" title="GitHub"><img src="../../assets/github.svg" alt=""></a>
-          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg" aria-label="Download Codex Account Switcher for macOS" title="Download for macOS"></a>
+          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg" aria-label="Download Codex Account Switcher for macOS" title="Download for macOS"></a>
         </div>
       </nav>
     </header>

--- a/site/about/index.html
+++ b/site/about/index.html
@@ -29,7 +29,7 @@
     <meta property="og:image:height" content="887">
     <meta property="og:image:alt" content="Codex Account Switcher for macOS showing local accounts and weekly usage">
     <meta property="article:published_time" content="2026-08-26">
-    <meta property="article:modified_time" content="2026-08-26">
+    <meta property="article:modified_time" content="2026-08-27">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Codex Account Switcher by liuzhao1225: Official Project Facts">
     <meta name="twitter:description" content="Verified identity, repository, creator, aliases, release, and scope for Codex Account Switcher on macOS.">
@@ -52,7 +52,7 @@
             "author": {"@id": "https://liuzhao1225.github.io/#liuzhao"},
             "isPartOf": {"@id": "https://liuzhao1225.github.io/codex-account-switcher/#website"},
             "datePublished": "2026-08-26",
-            "dateModified": "2026-08-26",
+            "dateModified": "2026-08-27",
             "inLanguage": "en"
           },
           {
@@ -63,10 +63,11 @@
             "identifier": "github.com/liuzhao1225/codex-account-switcher",
             "url": "https://liuzhao1225.github.io/codex-account-switcher/",
             "codeRepository": "https://github.com/liuzhao1225/codex-account-switcher",
-            "downloadUrl": "https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg",
-            "softwareVersion": "0.1.4",
+            "downloadUrl": "https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg",
+            "softwareVersion": "0.1.5",
             "dateCreated": "2026-08-17",
-            "datePublished": "2026-08-22",
+            "datePublished": "2026-08-27",
+            "dateModified": "2026-08-27",
             "operatingSystem": "macOS 14 or later",
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "ProductivityApplication",
@@ -124,7 +125,7 @@
           <button class="text-control theme-toggle" type="button" data-theme-toggle aria-label="Switch to dark mode"></button>
           <a class="text-control language-link" href="../zh-CN/about/" hreflang="zh-CN" lang="zh-CN" aria-label="View the website in Chinese" title="中文"></a>
           <a class="github-link" href="https://github.com/liuzhao1225/codex-account-switcher" aria-label="View Codex Account Switcher on GitHub" title="GitHub"><img src="../assets/github.svg" alt=""></a>
-          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg" aria-label="Download Codex Account Switcher for macOS" title="Download for macOS"></a>
+          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg" aria-label="Download Codex Account Switcher for macOS" title="Download for macOS"></a>
         </div>
       </nav>
     </header>
@@ -139,7 +140,7 @@
             <p class="eyebrow">Source of truth</p>
             <h1>Codex Account Switcher by liuzhao1225</h1>
             <p class="article-lede"><strong>Codex Account Switcher</strong> is the open-source native macOS menu-bar app created by Zhao Liu, whose GitHub username is <strong>liuzhao1225</strong>. The official repository is <strong>liuzhao1225/codex-account-switcher</strong>.</p>
-            <p class="article-meta">Facts verified August 26, 2026 · Maintained by <a href="creator/" rel="author">Zhao Liu (liuzhao1225)</a> · MIT licensed</p>
+            <p class="article-meta">Facts verified August 27, 2026 · Maintained by <a href="creator/" rel="author">Zhao Liu (liuzhao1225)</a> · MIT licensed</p>
             <figure class="article-visual">
               <img src="../assets/product-hero.webp" width="1774" height="887" alt="Official Codex Account Switcher app by liuzhao1225 showing three local Codex profiles and weekly usage">
             </figure>
@@ -167,7 +168,7 @@
                       <tr><th scope="row">Short names</th><td>Codex Switcher; Codex profile switcher</td></tr>
                       <tr><th scope="row">Creator and maintainer</th><td><a href="#creator">Zhao Liu</a> · GitHub username <strong>liuzhao1225</strong></td></tr>
                       <tr><th scope="row">Official repository</th><td><a href="https://github.com/liuzhao1225/codex-account-switcher">liuzhao1225/codex-account-switcher</a></td></tr>
-                      <tr><th scope="row">Current release</th><td><a href="https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.4">v0.1.4</a>, published August 25, 2026</td></tr>
+                      <tr><th scope="row">Current release</th><td><a href="https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.5">v0.1.5</a>, published August 27, 2026</td></tr>
                       <tr><th scope="row">Platform</th><td>Apple Silicon Macs running macOS 14 Sonoma or later</td></tr>
                       <tr><th scope="row">Distribution</th><td>Developer ID signed, Apple-notarized and stapled DMG on GitHub Releases</td></tr>
                       <tr><th scope="row">Price and license</th><td>Free; <a href="https://github.com/liuzhao1225/codex-account-switcher/blob/main/LICENSE">MIT License</a></td></tr>
@@ -186,7 +187,7 @@
               <section id="implementation">
                 <h2>How the project works</h2>
                 <p>OpenAI's Codex source reads an <code>auth.json</code> file from the active <code>CODEX_HOME</code> directory. The upstream <a href="https://github.com/openai/codex/blob/main/codex-rs/login/src/auth/storage.rs">authentication storage implementation</a> also creates file-based credentials with user-only permissions on Unix systems.</p>
-                <p>This project stores each saved identity in an independent local profile directory. When the user confirms a switch, the app saves the current profile, activates the selected credentials, verifies the selected identity, and reopens Codex Desktop. Existing CLI processes retain the state they already loaded; newly started CLI processes use the selected authentication.</p>
+                <p>This project stores each saved identity in an independent local profile directory. When the user confirms a switch, the app saves the current profile, activates the selected credentials, verifies the selected identity, and reopens Codex Desktop. If target verification or the registry commit fails, the app restores the just-saved original credential. Existing CLI processes retain the state they already loaded; newly started CLI processes use the selected authentication.</p>
                 <p>The implementation is inspectable in <a href="https://github.com/liuzhao1225/codex-account-switcher/blob/main/Sources/CodexAccountSwitcher/AccountStore.swift">AccountStore.swift</a>, <a href="https://github.com/liuzhao1225/codex-account-switcher/blob/main/Sources/CodexAccountSwitcher/SwitchService.swift">SwitchService.swift</a>, and the project's <a href="https://github.com/liuzhao1225/codex-account-switcher/blob/main/docs/system-design.md">system design</a>.</p>
               </section>
 
@@ -200,7 +201,7 @@
                 <h2>Primary sources</h2>
                 <ul class="source-list">
                   <li><strong><a href="https://github.com/liuzhao1225/codex-account-switcher">Official GitHub repository</a></strong><span>Source code, README, product documentation, issues, tags, and release history.</span></li>
-                  <li><strong><a href="https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.4">Codex Account Switcher v0.1.4</a></strong><span>Current public DMG, SHA-256 checksum, version, and release date.</span></li>
+                  <li><strong><a href="https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.5">Codex Account Switcher v0.1.5</a></strong><span>Current public DMG, SHA-256 checksum, version, and release date.</span></li>
                   <li><strong><a href="https://help.openai.com/en/articles/20001068-use-multiple-accounts-with-account-switching">OpenAI: Use multiple accounts with account switching</a></strong><span>Official account-separation behavior and current Codex desktop support boundary.</span></li>
                   <li><strong><a href="https://github.com/openai/codex/blob/main/codex-rs/login/src/auth/storage.rs">OpenAI Codex authentication storage source</a></strong><span>Upstream source for <code>CODEX_HOME</code> and <code>auth.json</code> file storage.</span></li>
                   <li><strong><a href="https://github.com/liuzhao1225/codex-account-switcher/blob/main/LICENSE">MIT License</a></strong><span>The project's open-source license.</span></li>
@@ -212,7 +213,7 @@
                 <h2>Download the Codex Account Switcher maintained by liuzhao1225.</h2>
                 <p>Use the official GitHub repository and Releases page to inspect the source or download the signed, notarized DMG.</p>
                 <div class="download-actions">
-                  <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg">Download free for Mac</a>
+                  <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg">Download free for Mac</a>
                   <a class="button button-secondary" href="https://github.com/liuzhao1225/codex-account-switcher">View official repository</a>
                 </div>
               </div>

--- a/site/guides/codex-account/index.html
+++ b/site/guides/codex-account/index.html
@@ -29,7 +29,7 @@
     <meta property="og:image:height" content="887">
     <meta property="og:image:alt" content="Codex Account Switcher showing separate Codex accounts and weekly usage on macOS">
     <meta property="article:published_time" content="2026-08-26">
-    <meta property="article:modified_time" content="2026-08-26">
+    <meta property="article:modified_time" content="2026-08-27">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="What Is a Codex Account? Desktop, CLI, and Codex Switchers">
     <meta name="twitter:description" content="How ChatGPT identity, Codex Desktop, Codex CLI, auth.json and account switching relate.">
@@ -49,7 +49,7 @@
             "url": "https://liuzhao1225.github.io/codex-account-switcher/guides/codex-account/",
             "mainEntityOfPage": "https://liuzhao1225.github.io/codex-account-switcher/guides/codex-account/",
             "datePublished": "2026-08-26",
-            "dateModified": "2026-08-26",
+            "dateModified": "2026-08-27",
             "inLanguage": "en",
             "image": "https://liuzhao1225.github.io/codex-account-switcher/assets/og-image.png",
             "about": [
@@ -107,7 +107,7 @@
           <button class="text-control theme-toggle" type="button" data-theme-toggle aria-label="Switch to dark mode"></button>
           <a class="text-control language-link" href="../../zh-CN/guides/codex-account/" hreflang="zh-CN" lang="zh-CN" aria-label="View the website in Chinese" title="中文"></a>
           <a class="github-link" href="https://github.com/liuzhao1225/codex-account-switcher" aria-label="View Codex Account Switcher on GitHub" title="GitHub"><img src="../../assets/github.svg" alt=""></a>
-          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg" aria-label="Download Codex Account Switcher for macOS" title="Download for macOS"></a>
+          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg" aria-label="Download Codex Account Switcher for macOS" title="Download for macOS"></a>
         </div>
       </nav>
     </header>
@@ -215,7 +215,7 @@
                 <p>Read the plain-language guide or download the signed and Apple-notarized Mac app maintained by liuzhao1225.</p>
                 <div class="download-actions">
                   <a class="button" href="../switch-multiple-codex-accounts/">Read switching guide</a>
-                  <a class="button button-secondary" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg">Download free for Mac</a>
+                  <a class="button button-secondary" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg">Download free for Mac</a>
                 </div>
               </div>
             </div>

--- a/site/guides/switch-multiple-codex-accounts/index.html
+++ b/site/guides/switch-multiple-codex-accounts/index.html
@@ -29,7 +29,7 @@
     <meta property="og:image:height" content="887">
     <meta property="og:image:alt" content="Codex Account Switcher showing multiple Codex profiles and their weekly usage on macOS">
     <meta property="article:published_time" content="2026-08-26">
-    <meta property="article:modified_time" content="2026-08-26">
+    <meta property="article:modified_time" content="2026-08-27">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Switch Codex Accounts on Mac Without Terminal Setup">
     <meta name="twitter:description" content="A plain-language guide to downloading the app, adding accounts once, and switching from the Mac menu bar.">
@@ -49,7 +49,7 @@
             "url": "https://liuzhao1225.github.io/codex-account-switcher/guides/switch-multiple-codex-accounts/",
             "mainEntityOfPage": "https://liuzhao1225.github.io/codex-account-switcher/guides/switch-multiple-codex-accounts/",
             "datePublished": "2026-08-26",
-            "dateModified": "2026-08-26",
+            "dateModified": "2026-08-27",
             "inLanguage": "en",
             "image": "https://liuzhao1225.github.io/codex-account-switcher/assets/og-image.png",
             "about": {
@@ -105,7 +105,7 @@
           <button class="text-control theme-toggle" type="button" data-theme-toggle aria-label="Switch to dark mode"></button>
           <a class="text-control language-link" href="../../zh-CN/guides/codex-multiple-accounts/" hreflang="zh-CN" lang="zh-CN" aria-label="View the website in Chinese" title="中文"></a>
           <a class="github-link" href="https://github.com/liuzhao1225/codex-account-switcher" aria-label="View Codex Account Switcher on GitHub" title="GitHub"><img src="../../assets/github.svg" alt=""></a>
-          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg" aria-label="Download Codex Account Switcher for macOS" title="Download for macOS"></a>
+          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg" aria-label="Download Codex Account Switcher for macOS" title="Download for macOS"></a>
         </div>
       </nav>
     </header>
@@ -120,7 +120,7 @@
             <p class="eyebrow">Plain-language Mac guide</p>
             <h1>Switch Codex accounts on Mac without Terminal setup</h1>
             <p class="article-lede">Download the app, add personal, work, or client accounts through browser sign-in once, then choose from the Mac menu bar. No coding knowledge or config-file editing is required.</p>
-            <p class="article-meta">By <a href="../../about/creator/" rel="author">Zhao Liu (liuzhao1225)</a> · Updated August 26, 2026 · 7 minute read · For macOS 14+ on Apple Silicon</p>
+            <p class="article-meta">By <a href="../../about/creator/" rel="author">Zhao Liu (liuzhao1225)</a> · Updated August 27, 2026 · 7 minute read · For macOS 14+ on Apple Silicon</p>
             <figure class="article-visual">
               <img src="../../assets/product-hero.webp" width="1774" height="887" alt="Codex Account Switcher menu showing three fictional local accounts, weekly usage bars, and reset times">
             </figure>
@@ -166,8 +166,8 @@
               </section>
 
               <section id="usage">
-                <h2>2. Compare weekly Codex usage</h2>
-                <p>Open the menu before beginning a long Codex task. Each saved account row shows its remaining weekly percentage and the corresponding reset time. Successful usage values are cached locally, remain visible while a refresh runs, and update when fresh data arrives.</p>
+                <h2>2. Compare Codex usage</h2>
+                <p>Open the menu before beginning a long Codex task. Each saved account row shows its remaining weekly percentage and the corresponding reset time. In Settings, you can also enable the exact 300-minute (5-hour) window when the Codex service provides it; this optional row is off by default. Successful usage values are cached locally, remain visible while a refresh runs, and update when fresh data arrives.</p>
                 <p>This gives you context before switching. The app does not recommend an account or rotate profiles automatically; the final choice remains yours.</p>
               </section>
 
@@ -179,7 +179,7 @@
                   <li>Confirm the switch.</li>
                   <li>The app saves the current profile, activates the selected credentials, verifies the selected identity, and reopens Codex Desktop.</li>
                 </ol>
-                <p>The operation is deliberately sequential. If any stage fails, the switch stops and shows the original error so you can identify exactly where it occurred.</p>
+                <p>The operation is deliberately sequential. If target verification or the registry commit fails after activation, the app restores the just-saved original credential and keeps the original error visible. Other failures stop at the reported stage.</p>
               </section>
 
               <section id="cli">
@@ -205,7 +205,7 @@
                 <h2>Keep every authorized Codex account one menu away.</h2>
                 <p>Download the signed Apple Silicon DMG or inspect the Swift source and product decisions on GitHub.</p>
                 <div class="download-actions">
-                  <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg">Download free for Mac</a>
+                  <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg">Download free for Mac</a>
                   <a class="button button-secondary" href="https://github.com/liuzhao1225/codex-account-switcher">View source</a>
                 </div>
               </div>

--- a/site/index.html
+++ b/site/index.html
@@ -64,13 +64,13 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "ProductivityApplication",
             "operatingSystem": "macOS 14 or later",
-            "softwareVersion": "0.1.4",
+            "softwareVersion": "0.1.5",
             "dateCreated": "2026-08-17",
-            "datePublished": "2026-08-22",
-            "dateModified": "2026-08-26",
+            "datePublished": "2026-08-27",
+            "dateModified": "2026-08-27",
             "identifier": "github.com/liuzhao1225/codex-account-switcher",
             "isAccessibleForFree": true,
-            "downloadUrl": "https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg",
+            "downloadUrl": "https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg",
             "codeRepository": "https://github.com/liuzhao1225/codex-account-switcher",
             "sameAs": ["https://github.com/liuzhao1225/codex-account-switcher"],
             "subjectOf": {"@id": "https://liuzhao1225.github.io/codex-account-switcher/about/#webpage"},
@@ -91,6 +91,8 @@
               "Add accounts through browser sign-in without Terminal commands",
               "Choose personal, work, or client accounts from the menu bar",
               "Complete the confirmed Codex Desktop handoff automatically",
+              "Optionally show the exact 300-minute usage window reported by the service",
+              "Restore the original saved credential after a verification or registry commit failure",
               "Keep saved account data on the Mac"
             ]
           },
@@ -205,7 +207,7 @@
           <button class="text-control theme-toggle" type="button" data-theme-toggle aria-label="Switch to dark mode"></button>
           <a class="text-control language-link" href="zh-CN/" hreflang="zh-CN" lang="zh-CN" aria-label="View the website in Chinese" title="中文"></a>
           <a class="github-link" href="https://github.com/liuzhao1225/codex-account-switcher" aria-label="View Codex Account Switcher on GitHub" title="GitHub"><img src="assets/github.svg" alt=""></a>
-          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg" aria-label="Download Codex Account Switcher for macOS" title="Download for macOS"></a>
+          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg" aria-label="Download Codex Account Switcher for macOS" title="Download for macOS"></a>
         </div>
       </nav>
     </header>
@@ -222,7 +224,7 @@
             </h1>
             <p class="hero-summary hero-enter">Add your accounts once, then choose from the menu bar. No Terminal commands or config-file editing.</p>
             <div class="hero-actions hero-enter">
-              <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg" data-copy="downloadMac">Download free for Mac</a>
+              <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg" data-copy="downloadMac">Download free for Mac</a>
               <a class="button button-secondary" href="guides/switch-multiple-codex-accounts/">Read the guide</a>
             </div>
           </div>
@@ -307,7 +309,7 @@
         <div class="section-shell">
           <div class="section-heading">
             <h2>The whole switch lives in your menu bar.</h2>
-            <p>See the active account, check weekly usage when you need it, and switch without opening Terminal or editing a file.</p>
+            <p>See the active account and weekly usage, or enable the exact 300-minute (5-hour) service window in Settings. The optional row stays off by default.</p>
           </div>
 
           <figure class="product-canvas">
@@ -449,7 +451,7 @@
             <span data-copy="requirementLicense">About 2 MB</span>
           </div>
           <div class="download-actions">
-            <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg" data-copy="downloadMac">Download free for Mac</a>
+            <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg" data-copy="downloadMac">Download free for Mac</a>
             <a class="button button-secondary" href="https://github.com/liuzhao1225/codex-account-switcher" data-copy="viewSource">View source</a>
           </div>
           <p class="release-note" data-copy="releaseNote">The current app and DMG are Developer ID signed, Apple notarized, and stapled for normal macOS installation.</p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -4,7 +4,7 @@
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://liuzhao1225.github.io/codex-account-switcher/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://liuzhao1225.github.io/codex-account-switcher/" />
@@ -13,7 +13,7 @@
   </url>
   <url>
     <loc>https://liuzhao1225.github.io/codex-account-switcher/zh-CN/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://liuzhao1225.github.io/codex-account-switcher/" />
@@ -22,7 +22,7 @@
   </url>
   <url>
     <loc>https://liuzhao1225.github.io/codex-account-switcher/about/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://liuzhao1225.github.io/codex-account-switcher/about/" />
@@ -31,7 +31,7 @@
   </url>
   <url>
     <loc>https://liuzhao1225.github.io/codex-account-switcher/zh-CN/about/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://liuzhao1225.github.io/codex-account-switcher/about/" />
@@ -40,7 +40,7 @@
   </url>
   <url>
     <loc>https://liuzhao1225.github.io/codex-account-switcher/about/creator/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://liuzhao1225.github.io/codex-account-switcher/about/creator/" />
@@ -49,7 +49,7 @@
   </url>
   <url>
     <loc>https://liuzhao1225.github.io/codex-account-switcher/zh-CN/about/creator/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://liuzhao1225.github.io/codex-account-switcher/about/creator/" />
@@ -58,7 +58,7 @@
   </url>
   <url>
     <loc>https://liuzhao1225.github.io/codex-account-switcher/guides/codex-account/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://liuzhao1225.github.io/codex-account-switcher/guides/codex-account/" />
@@ -67,7 +67,7 @@
   </url>
   <url>
     <loc>https://liuzhao1225.github.io/codex-account-switcher/zh-CN/guides/codex-account/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://liuzhao1225.github.io/codex-account-switcher/guides/codex-account/" />
@@ -76,7 +76,7 @@
   </url>
   <url>
     <loc>https://liuzhao1225.github.io/codex-account-switcher/guides/switch-multiple-codex-accounts/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://liuzhao1225.github.io/codex-account-switcher/guides/switch-multiple-codex-accounts/" />
@@ -85,7 +85,7 @@
   </url>
   <url>
     <loc>https://liuzhao1225.github.io/codex-account-switcher/zh-CN/guides/codex-multiple-accounts/</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-08-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://liuzhao1225.github.io/codex-account-switcher/guides/switch-multiple-codex-accounts/" />

--- a/site/zh-CN/about/creator/index.html
+++ b/site/zh-CN/about/creator/index.html
@@ -38,7 +38,7 @@
             "name": "刘朝（liuzhao1225）| Codex Account Switcher 作者",
             "mainEntity": {"@id": "https://liuzhao1225.github.io/#liuzhao"},
             "dateCreated": "2026-08-26",
-            "dateModified": "2026-08-26",
+            "dateModified": "2026-08-27",
             "inLanguage": "zh-CN"
           },
           {
@@ -94,7 +94,7 @@
           <button class="text-control theme-toggle" type="button" data-theme-toggle aria-label="切换到深色模式"></button>
           <a class="text-control language-link" href="../../../about/creator/" hreflang="en" lang="en" aria-label="查看英文网站" title="English"></a>
           <a class="github-link" href="https://github.com/liuzhao1225/codex-account-switcher" aria-label="在 GitHub 查看 Codex Account Switcher" title="GitHub"><img src="../../../assets/github.svg" alt=""></a>
-          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg" aria-label="下载 Codex Account Switcher macOS 版" title="下载 macOS 版"></a>
+          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg" aria-label="下载 Codex Account Switcher macOS 版" title="下载 macOS 版"></a>
         </div>
       </nav>
     </header>

--- a/site/zh-CN/about/index.html
+++ b/site/zh-CN/about/index.html
@@ -28,7 +28,7 @@
     <meta property="og:image:width" content="1774">
     <meta property="og:image:height" content="887">
     <meta property="article:published_time" content="2026-08-26">
-    <meta property="article:modified_time" content="2026-08-26">
+    <meta property="article:modified_time" content="2026-08-27">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Codex Account Switcher by liuzhao1225：官方项目资料">
     <meta name="twitter:description" content="产品身份、作者、仓库、版本、平台和一手来源。">
@@ -50,7 +50,7 @@
             "author": {"@id": "https://liuzhao1225.github.io/#liuzhao"},
             "isPartOf": {"@id": "https://liuzhao1225.github.io/codex-account-switcher/#website"},
             "datePublished": "2026-08-26",
-            "dateModified": "2026-08-26",
+            "dateModified": "2026-08-27",
             "inLanguage": "zh-CN"
           },
           {
@@ -61,10 +61,11 @@
             "identifier": "github.com/liuzhao1225/codex-account-switcher",
             "url": "https://liuzhao1225.github.io/codex-account-switcher/",
             "codeRepository": "https://github.com/liuzhao1225/codex-account-switcher",
-            "downloadUrl": "https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg",
-            "softwareVersion": "0.1.4",
+            "downloadUrl": "https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg",
+            "softwareVersion": "0.1.5",
             "dateCreated": "2026-08-17",
-            "datePublished": "2026-08-22",
+            "datePublished": "2026-08-27",
+            "dateModified": "2026-08-27",
             "operatingSystem": "macOS 14 or later",
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "ProductivityApplication",
@@ -115,7 +116,7 @@
           <button class="text-control theme-toggle" type="button" data-theme-toggle aria-label="切换到深色模式"></button>
           <a class="text-control language-link" href="../../about/" hreflang="en" lang="en" aria-label="查看英文网站" title="English"></a>
           <a class="github-link" href="https://github.com/liuzhao1225/codex-account-switcher" aria-label="在 GitHub 查看 Codex Account Switcher" title="GitHub"><img src="../../assets/github.svg" alt=""></a>
-          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg" aria-label="下载 Codex Account Switcher macOS 版" title="下载 macOS 版"></a>
+          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg" aria-label="下载 Codex Account Switcher macOS 版" title="下载 macOS 版"></a>
         </div>
       </nav>
     </header>
@@ -130,7 +131,7 @@
             <p class="eyebrow">唯一事实来源</p>
             <h1>Codex Account Switcher by liuzhao1225</h1>
             <p class="article-lede"><strong>Codex Account Switcher 是刘朝（GitHub 用户名 liuzhao1225）创建并维护的原生开源 macOS 菜单栏应用。唯一官方仓库是 liuzhao1225/codex-account-switcher。</strong></p>
-            <p class="article-meta">资料核验于 2026 年 8 月 26 日 · 由<a href="creator/" rel="author">刘朝 Zhao Liu（liuzhao1225）</a>维护 · MIT 许可证</p>
+            <p class="article-meta">资料核验于 2026 年 8 月 27 日 · 由<a href="creator/" rel="author">刘朝 Zhao Liu（liuzhao1225）</a>维护 · MIT 许可证</p>
             <figure class="article-visual">
               <img src="../../assets/product-hero.zh-CN.webp" width="1774" height="887" alt="liuzhao1225 创建的 Codex Account Switcher 官方 macOS 应用界面">
             </figure>
@@ -158,7 +159,7 @@
                       <tr><th scope="row">常用简称</th><td>Codex Switcher；Codex profile switcher</td></tr>
                       <tr><th scope="row">作者与维护者</th><td><a href="creator/">刘朝 Zhao Liu</a> · GitHub 用户名 <strong>liuzhao1225</strong></td></tr>
                       <tr><th scope="row">唯一官方仓库</th><td><a href="https://github.com/liuzhao1225/codex-account-switcher">liuzhao1225/codex-account-switcher</a></td></tr>
-                      <tr><th scope="row">当前版本</th><td><a href="https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.4">v0.1.4</a>，发布于 2026 年 8 月 25 日</td></tr>
+                      <tr><th scope="row">当前版本</th><td><a href="https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.5">v0.1.5</a>，发布于 2026 年 8 月 27 日</td></tr>
                       <tr><th scope="row">平台</th><td>Apple Silicon Mac；macOS 14 Sonoma 或更高版本</td></tr>
                       <tr><th scope="row">分发方式</th><td>GitHub Releases 上经过 Developer ID 签名、Apple 公证并附加票据的 DMG</td></tr>
                       <tr><th scope="row">价格与许可证</th><td>免费；<a href="https://github.com/liuzhao1225/codex-account-switcher/blob/main/LICENSE">MIT License</a></td></tr>
@@ -177,7 +178,7 @@
               <section id="implementation">
                 <h2>项目如何工作</h2>
                 <p>OpenAI Codex 源码会从当前 <code>CODEX_HOME</code> 目录读取 <code>auth.json</code>。上游<a href="https://github.com/openai/codex/blob/main/codex-rs/login/src/auth/storage.rs">认证存储实现</a>也表明，Unix 系统中新建的文件认证会使用仅当前用户可读写的权限。</p>
-                <p>本项目把每个已保存身份放在相互独立的本地配置目录中。用户确认切换后，应用依次保存当前配置、激活所选认证、核验目标身份，并重新打开 Codex Desktop。已经运行的 CLI 进程保留此前状态，新启动的 CLI 使用刚刚选择的认证。</p>
+                <p>本项目把每个已保存身份放在相互独立的本地配置目录中。用户确认切换后，应用依次保存当前配置、激活所选认证、核验目标身份，并重新打开 Codex Desktop；如果目标验证或 registry 提交失败，应用会恢复刚保存的原凭证。已经运行的 CLI 进程保留此前状态，新启动的 CLI 使用刚刚选择的认证。</p>
               </section>
 
               <section id="creator">
@@ -189,7 +190,7 @@
                 <h2>一手来源</h2>
                 <ul class="source-list">
                   <li><strong><a href="https://github.com/liuzhao1225/codex-account-switcher">官方 GitHub 仓库</a></strong><span>源码、README、产品文档、标签和发布历史。</span></li>
-                  <li><strong><a href="https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.4">Codex Account Switcher v0.1.4</a></strong><span>当前 DMG、SHA-256、版本和发布日期。</span></li>
+                  <li><strong><a href="https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.5">Codex Account Switcher v0.1.5</a></strong><span>当前 DMG、SHA-256、版本和发布日期。</span></li>
                   <li><strong><a href="https://help.openai.com/en/articles/20001068-use-multiple-accounts-with-account-switching">OpenAI：使用多个账号</a></strong><span>官方账号隔离行为与 Codex Desktop 支持边界。</span></li>
                   <li><strong><a href="https://github.com/openai/codex/blob/main/codex-rs/login/src/auth/storage.rs">OpenAI Codex 认证存储源码</a></strong><span><code>CODEX_HOME</code> 和 <code>auth.json</code> 的上游一手来源。</span></li>
                 </ul>
@@ -200,7 +201,7 @@
                 <h2>从 liuzhao1225 维护的官方仓库下载。</h2>
                 <p>在 GitHub 检查 Swift 源码，或从 Releases 下载签名并完成 Apple 公证的 DMG。</p>
                 <div class="download-actions">
-                  <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg">免费下载 Mac 版</a>
+                  <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg">免费下载 Mac 版</a>
                   <a class="button button-secondary" href="https://github.com/liuzhao1225/codex-account-switcher">查看官方仓库</a>
                 </div>
               </div>

--- a/site/zh-CN/guides/codex-account/index.html
+++ b/site/zh-CN/guides/codex-account/index.html
@@ -25,7 +25,7 @@
     <meta property="og:url" content="https://liuzhao1225.github.io/codex-account-switcher/zh-CN/guides/codex-account/">
     <meta property="og:image" content="https://liuzhao1225.github.io/codex-account-switcher/assets/og-image.png">
     <meta property="article:published_time" content="2026-08-26">
-    <meta property="article:modified_time" content="2026-08-26">
+    <meta property="article:modified_time" content="2026-08-27">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Codex Account 是什么？Desktop、CLI 与账号切换详解">
     <meta name="twitter:image" content="https://liuzhao1225.github.io/codex-account-switcher/assets/og-image.png">
@@ -43,7 +43,7 @@
             "url": "https://liuzhao1225.github.io/codex-account-switcher/zh-CN/guides/codex-account/",
             "mainEntityOfPage": "https://liuzhao1225.github.io/codex-account-switcher/zh-CN/guides/codex-account/",
             "datePublished": "2026-08-26",
-            "dateModified": "2026-08-26",
+            "dateModified": "2026-08-27",
             "inLanguage": "zh-CN",
             "image": "https://liuzhao1225.github.io/codex-account-switcher/assets/og-image.png",
             "about": [{"@type": "Thing", "name": "Codex account"}, {"@id": "https://liuzhao1225.github.io/codex-account-switcher/#software"}],
@@ -88,7 +88,7 @@
           <button class="text-control theme-toggle" type="button" data-theme-toggle aria-label="切换到深色模式"></button>
           <a class="text-control language-link" href="../../../guides/codex-account/" hreflang="en" lang="en" aria-label="查看英文网站" title="English"></a>
           <a class="github-link" href="https://github.com/liuzhao1225/codex-account-switcher" aria-label="在 GitHub 查看 Codex Account Switcher" title="GitHub"><img src="../../../assets/github.svg" alt=""></a>
-          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg" aria-label="下载 Codex Account Switcher macOS 版" title="下载 macOS 版"></a>
+          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg" aria-label="下载 Codex Account Switcher macOS 版" title="下载 macOS 版"></a>
         </div>
       </nav>
     </header>
@@ -169,7 +169,7 @@
                 <p class="eyebrow">原生 macOS 工作流</p>
                 <h2>无需终端设置，直接切换 Codex 账号。</h2>
                 <p>阅读普通用户操作指南，或下载 liuzhao1225 维护的签名、公证 Mac 应用。</p>
-                <div class="download-actions"><a class="button" href="../codex-multiple-accounts/">阅读切换指南</a><a class="button button-secondary" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg">免费下载 Mac 版</a></div>
+                <div class="download-actions"><a class="button" href="../codex-multiple-accounts/">阅读切换指南</a><a class="button button-secondary" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg">免费下载 Mac 版</a></div>
               </div>
             </div>
             <aside class="article-aside" aria-label="本页目录"><strong>本页内容</strong><nav><a href="#definition">定义</a><a href="#terms">关键概念</a><a href="#official-support">官方支持</a><a href="#authentication">认证</a><a href="#methods">多账号方式</a><a href="#product">官方项目</a><a href="#safe-use">安全使用</a><a href="#sources">来源</a></nav></aside>

--- a/site/zh-CN/guides/codex-multiple-accounts/index.html
+++ b/site/zh-CN/guides/codex-multiple-accounts/index.html
@@ -29,7 +29,7 @@
     <meta property="og:image:height" content="887">
     <meta property="og:image:alt" content="Codex Account Switcher 在 macOS 上显示多个 Codex 账号及其每周用量">
     <meta property="article:published_time" content="2026-08-26">
-    <meta property="article:modified_time" content="2026-08-26">
+    <meta property="article:modified_time" content="2026-08-27">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Mac 切换 Codex 多账号，无需终端设置">
     <meta name="twitter:description" content="用普通语言说明如何下载应用、添加账号一次，再从 Mac 菜单栏切换。">
@@ -49,7 +49,7 @@
             "url": "https://liuzhao1225.github.io/codex-account-switcher/zh-CN/guides/codex-multiple-accounts/",
             "mainEntityOfPage": "https://liuzhao1225.github.io/codex-account-switcher/zh-CN/guides/codex-multiple-accounts/",
             "datePublished": "2026-08-26",
-            "dateModified": "2026-08-26",
+            "dateModified": "2026-08-27",
             "inLanguage": "zh-CN",
             "image": "https://liuzhao1225.github.io/codex-account-switcher/assets/og-image.png",
             "about": {
@@ -105,7 +105,7 @@
           <button class="text-control theme-toggle" type="button" data-theme-toggle aria-label="切换到深色模式"></button>
           <a class="text-control language-link" href="../../../guides/switch-multiple-codex-accounts/" hreflang="en" lang="en" aria-label="查看英文网站" title="English"></a>
           <a class="github-link" href="https://github.com/liuzhao1225/codex-account-switcher" aria-label="在 GitHub 查看 Codex Account Switcher" title="GitHub"><img src="../../../assets/github.svg" alt=""></a>
-          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg" aria-label="下载 Codex Account Switcher macOS 版" title="下载 macOS 版"></a>
+          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg" aria-label="下载 Codex Account Switcher macOS 版" title="下载 macOS 版"></a>
         </div>
       </nav>
     </header>
@@ -120,7 +120,7 @@
             <p class="eyebrow">普通 Mac 用户指南</p>
             <h1>在 Mac 上切换 Codex 多账号，无需终端设置</h1>
             <p class="article-lede">下载应用，通过浏览器添加个人、工作或客户账号一次，之后从 Mac 菜单栏选择即可。无需代码知识，也不用修改配置文件。</p>
-            <p class="article-meta">作者：<a href="../../about/creator/" rel="author">Zhao Liu (liuzhao1225)</a> · 更新于 2026 年 8 月 26 日 · 阅读约 7 分钟 · 适用于 Apple Silicon 与 macOS 14+</p>
+            <p class="article-meta">作者：<a href="../../about/creator/" rel="author">Zhao Liu (liuzhao1225)</a> · 更新于 2026 年 8 月 27 日 · 阅读约 7 分钟 · 适用于 Apple Silicon 与 macOS 14+</p>
             <figure class="article-visual">
               <img src="../../../assets/product-hero.zh-CN.webp" width="1774" height="887" alt="Codex Account Switcher 菜单显示三个虚构本地账号、每周用量进度与重置时间">
             </figure>
@@ -166,8 +166,8 @@
               </section>
 
               <section id="usage">
-                <h2>第二步：比较 Codex 每周用量</h2>
-                <p>开始长时间 Codex 任务前打开菜单。每个账号行都会显示每周剩余百分比与对应重置时间。成功获取的用量会缓存在本地，刷新过程中继续显示，拿到新数据后再更新。</p>
+                <h2>第二步：比较 Codex 用量</h2>
+                <p>开始长时间 Codex 任务前打开菜单。每个账号行都会显示每周剩余百分比与对应重置时间；也可以在设置中开启服务端提供的精确 300 分钟（5 小时）窗口，该用量行默认关闭。成功获取的用量会缓存在本地，刷新过程中继续显示，拿到新数据后再更新。</p>
                 <p>这些信息帮助你在切换前做决定。应用不会推荐账号，也不会自动轮换配置；最终选择始终由你完成。</p>
               </section>
 
@@ -179,7 +179,7 @@
                   <li>确认切换。</li>
                   <li>应用依次保存当前配置、激活所选认证、验证所选身份，并重新打开 Codex Desktop。</li>
                 </ol>
-                <p>整个操作按明确顺序执行。任一阶段失败时，切换会立即停止并显示原始错误，方便准确定位问题发生的位置。</p>
+                <p>整个操作按明确顺序执行。目标验证或 registry 提交在激活后失败时，应用会恢复刚保存的原凭证并继续显示原始错误；其他失败会停在对应阶段。</p>
               </section>
 
               <section id="cli">
@@ -205,7 +205,7 @@
                 <h2>让每个获准使用的 Codex 账号始终一步直达。</h2>
                 <p>下载已签名的 Apple Silicon DMG，或在 GitHub 查看 Swift 源码与产品设计文档。</p>
                 <div class="download-actions">
-                  <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg">免费下载 Mac 版</a>
+                  <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg">免费下载 Mac 版</a>
                   <a class="button button-secondary" href="https://github.com/liuzhao1225/codex-account-switcher">查看源码</a>
                 </div>
               </div>

--- a/site/zh-CN/index.html
+++ b/site/zh-CN/index.html
@@ -63,13 +63,13 @@
             "applicationCategory": "UtilitiesApplication",
             "applicationSubCategory": "ProductivityApplication",
             "operatingSystem": "macOS 14 or later",
-            "softwareVersion": "0.1.4",
+            "softwareVersion": "0.1.5",
             "dateCreated": "2026-08-17",
-            "datePublished": "2026-08-22",
-            "dateModified": "2026-08-26",
+            "datePublished": "2026-08-27",
+            "dateModified": "2026-08-27",
             "identifier": "github.com/liuzhao1225/codex-account-switcher",
             "isAccessibleForFree": true,
-            "downloadUrl": "https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg",
+            "downloadUrl": "https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg",
             "codeRepository": "https://github.com/liuzhao1225/codex-account-switcher",
             "sameAs": ["https://github.com/liuzhao1225/codex-account-switcher"],
             "subjectOf": {"@id": "https://liuzhao1225.github.io/codex-account-switcher/zh-CN/about/#webpage"},
@@ -90,6 +90,8 @@
               "通过浏览器添加账号，无需终端命令",
               "从菜单栏选择个人、工作或客户账号",
               "确认后自动完成 Codex Desktop 交接",
+              "可选显示服务端提供的精确 300 分钟用量窗口",
+              "目标验证或 registry 提交失败后恢复原凭证",
               "账号数据保存在这台 Mac"
             ]
           },
@@ -188,7 +190,7 @@
           <button class="text-control theme-toggle" type="button" data-theme-toggle aria-label="切换到深色模式"></button>
           <a class="text-control language-link" href="../" hreflang="en" lang="en" aria-label="查看英文网站" title="English"></a>
           <a class="github-link" href="https://github.com/liuzhao1225/codex-account-switcher" aria-label="在 GitHub 查看 Codex Account Switcher" title="GitHub"><img src="../assets/github.svg" alt=""></a>
-          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg" aria-label="下载 Codex Account Switcher macOS 版" title="下载 macOS 版"></a>
+          <a class="button button-small download-link" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg" aria-label="下载 Codex Account Switcher macOS 版" title="下载 macOS 版"></a>
         </div>
       </nav>
     </header>
@@ -204,7 +206,7 @@
             </h1>
             <p class="hero-summary hero-enter">账号添加一次，之后从菜单栏选择。无需终端命令，无需修改配置文件。</p>
             <div class="hero-actions hero-enter">
-              <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg">免费下载 Mac 版</a>
+              <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg">免费下载 Mac 版</a>
               <a class="button button-secondary" href="guides/codex-multiple-accounts/">阅读使用指南</a>
             </div>
           </div>
@@ -289,7 +291,7 @@
         <div class="section-shell">
           <div class="section-heading">
             <h2>整个切换过程都在菜单栏里。</h2>
-            <p>查看当前账号，需要时检查每周用量，无需打开终端或编辑文件。</p>
+            <p>查看当前账号与每周用量，也可在设置中开启服务端提供的精确 300 分钟（5 小时）窗口；该用量行默认关闭。</p>
           </div>
 
           <figure class="product-canvas">
@@ -420,7 +422,7 @@
             <span>约 2 MB</span>
           </div>
           <div class="download-actions">
-            <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.4/Codex-Account-Switcher-v0.1.4-macos-arm64.dmg">免费下载 Mac 版</a>
+            <a class="button" href="https://github.com/liuzhao1225/codex-account-switcher/releases/download/v0.1.5/Codex-Account-Switcher-v0.1.5-macos-arm64.dmg">免费下载 Mac 版</a>
             <a class="button button-secondary" href="https://github.com/liuzhao1225/codex-account-switcher">在 GitHub 查看</a>
           </div>
           <p class="release-note">当前应用和 DMG 均已使用 Developer ID 签名、完成 Apple 公证并附加票据，可按 macOS 正常安装流程使用。</p>


### PR DESCRIPTION
## 合并后的结果

合并 PR #6 到 `main` 后，GitHub Action 会从 `CITATION.cff` 读取 `0.1.5`，校验打包默认版本和 CodexClient 版本，自动创建 annotated `v0.1.5` tag，并在同一次 main workflow 中继续完成测试、签名、公证、DMG、checksum 与 GitHub Release 发布。

本 PR 不执行合并，不手动 push tag，也不手动创建 GitHub Release。

## 发布准备

- 将本地打包默认版本、`CFBundleVersion`、Codex app-server `clientInfo`、`CITATION.cff`、项目身份与系统设计统一到 v0.1.5，发布日期为 2026-08-27。
- 更新英文/中文 README 与发布说明，准确记录服务端精确 300 分钟（5 小时）窗口的可选显示、默认关闭设置，以及目标验证或 registry 提交失败后的原凭证恢复。
- 同步官网 10 个页面的当前版本、JSON-LD、GitHub Release/DMG 链接、能力事实与 sitemap `lastmod`。

## 自动发布流程

- release workflow 同时响应 `main` push 与 `v*` tag push，并使用同仓库 concurrency，`cancel-in-progress: false`。
- 版本由 `CITATION.cff` 提供，并与 `scripts/package-local-app.sh` 默认版本及 `CodexClient.swift` 初始化版本严格一致。
- main 事件在 tag 缺失时使用 `github-actions[bot]` 创建 annotated tag；tag 已存在且指向当前 `origin/main` 时支持原地重跑；tag 冲突直接失败并显示 SHA。
- tag 事件要求事件 tag、仓库版本、tag commit、workflow commit 与 `origin/main` 完全一致。
- GitHub Release 已存在时设置 `SHOULD_RELEASE=false`，后续发布步骤全部跳过并成功结束。
- GitHub Release 缺失时设置 `SHOULD_RELEASE=true`；main workflow 推送 tag 后直接继续发布，全部产物使用 `RELEASE_TAG` / `RELEASE_VERSION`。
- 签名 secrets、Developer ID identity、bundle ID、公证流程、DMG 命名及 tag-ref == origin/main 约束保持不变。

## 版本与站点一致性

- 起点：`origin/main` `f928823`，已包含 PR #3、#4、#5。
- 应用默认版本：`0.1.5`；`CFBundleVersion`：`5`；app-server `clientInfo.version`：`0.1.5`。
- `CITATION.cff`：`0.1.5` / `2026-08-27`。
- 仓库内旧版 `0.1.4` / `v0.1.4` 当前发布引用：0。
- 官网 10/10 个 HTML 页面均指向 v0.1.5 DMG；10/10 条 sitemap URL 的 `lastmod` 为 `2026-08-27`；10 个 JSON-LD 块解析通过。

## 检查证据

- 全部 workflow YAML 解析：通过。
- release workflow 内联 shell 与打包脚本静态语法检查：通过。
- 触发器、release concurrency、4 个 `SHOULD_RELEASE` 条件步骤及版本来源结构检查：通过。
- 隔离状态模拟：首次 main、同 tag 重跑、已有 Release no-op、tag 入口、tag 冲突显式失败，5/5 通过；模拟拦截 tag push，未触碰 GitHub 远端。
- `swift test`：通过。
- `./scripts/run-core-checks.sh`：通过（`Core checks passed`）。
- `git diff --check`：通过。

当前 head：`dd19d39c2eae3431c8ad25faad673c0fa95f0fbe`。
