### PR TITLE
改为仅由版本标签触发发布

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release macOS app
 
 on:
   push:
-    branches:
-      - main
     tags:
       - "v*"
 
@@ -25,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Resolve release version, tag, and action
+      - name: Validate release tag and resolve action
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -52,37 +50,28 @@ jobs:
           fi
 
           release_tag="v${release_version}"
-          head_sha=$(git rev-parse HEAD^{commit})
-          main_sha=$(git rev-parse origin/main^{commit})
+          if [[ "$GITHUB_REF" != refs/tags/* ]]; then
+            echo "Unsupported release ref '$GITHUB_REF'; only v* tag pushes may publish a release" >&2
+            exit 1
+          fi
 
-          case "$GITHUB_REF" in
-            refs/heads/main)
-              if [[ "$head_sha" != "$main_sha" ]]; then
-                echo "main workflow commit $head_sha is not current origin/main $main_sha" >&2
-                exit 1
-              fi
-              ;;
-            refs/tags/*)
-              event_tag=${GITHUB_REF#refs/tags/}
-              if [[ "$event_tag" != "$release_tag" ]]; then
-                echo "Tag event '$event_tag' does not match repository version '$release_tag'" >&2
-                exit 1
-              fi
-              if ! git show-ref --verify --quiet "refs/tags/${release_tag}"; then
-                echo "Tag event ref 'refs/tags/${release_tag}' was not fetched" >&2
-                exit 1
-              fi
-              tag_commit=$(git rev-parse "refs/tags/${release_tag}^{commit}")
-              if [[ "$head_sha" != "$main_sha" || "$tag_commit" != "$main_sha" ]]; then
-                echo "Tag '$release_tag' commit $tag_commit and workflow commit $head_sha must both equal origin/main $main_sha" >&2
-                exit 1
-              fi
-              ;;
-            *)
-              echo "Unsupported release ref '$GITHUB_REF'" >&2
-              exit 1
-              ;;
-          esac
+          event_tag=${GITHUB_REF#refs/tags/}
+          if [[ "$event_tag" != "$release_tag" ]]; then
+            echo "Tag event '$event_tag' does not match repository version '$release_tag'" >&2
+            exit 1
+          fi
+          if ! git show-ref --verify --quiet "refs/tags/${release_tag}"; then
+            echo "Tag event ref 'refs/tags/${release_tag}' was not fetched" >&2
+            exit 1
+          fi
+
+          head_sha=$(git rev-parse HEAD^{commit})
+          tag_commit=$(git rev-parse "refs/tags/${release_tag}^{commit}")
+          main_sha=$(git rev-parse origin/main^{commit})
+          if [[ "$head_sha" != "$main_sha" || "$tag_commit" != "$main_sha" ]]; then
+            echo "Tag '$release_tag' commit $tag_commit and workflow commit $head_sha must both equal origin/main $main_sha" >&2
+            exit 1
+          fi
 
           {
             echo "RELEASE_VERSION=$release_version"
@@ -98,31 +87,8 @@ jobs:
             exit 0
           fi
 
-          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
-            if git show-ref --verify --quiet "refs/tags/${release_tag}"; then
-              tag_commit=$(git rev-parse "refs/tags/${release_tag}^{commit}")
-              if [[ "$tag_commit" != "$main_sha" ]]; then
-                echo "Tag conflict: '$release_tag' points to $tag_commit, expected current origin/main $main_sha" >&2
-                exit 1
-              fi
-              echo "Reusing existing tag '$release_tag' at $tag_commit."
-            else
-              git config user.name "github-actions[bot]"
-              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-              git tag -a "$release_tag" "$main_sha" -m "Codex Account Switcher $release_tag"
-              git push origin "refs/tags/${release_tag}"
-              echo "Created annotated tag '$release_tag' at $main_sha."
-            fi
-          fi
-
-          resolved_tag_commit=$(git rev-parse "refs/tags/${release_tag}^{commit}")
-          if [[ "$resolved_tag_commit" != "$main_sha" ]]; then
-            echo "Resolved tag '$release_tag' points to $resolved_tag_commit, expected origin/main $main_sha" >&2
-            exit 1
-          fi
-
           echo "SHOULD_RELEASE=true" >> "$GITHUB_ENV"
-          echo "Publishing '$release_tag' from $main_sha in this workflow run." | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "Publishing existing tag '$release_tag' from current origin/main $main_sha in this workflow run." | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Validate release toolchain
         if: env.SHOULD_RELEASE == 'true'

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Comparisons with other account switchers are welcome. Please describe the workfl
 | Area | Status |
 | --- | --- |
 | Apple Silicon build | Available in [v0.1.5](https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.5) |
-| Automation | PR CI runs tests; merging a prepared version to `main` creates its tag and publishes the signed release |
+| Automation | PR and `main` CI run tests; pushing a matching `v*` tag publishes the signed release |
 | Code signing | Developer ID Application |
 | Apple notarization | App and DMG notarized and stapled |
 | Distribution container | DMG with SHA-256 checksum |
@@ -151,9 +151,9 @@ The bundle is written to `.build/release/Codex Account Switcher.app`.
 
 ### Automated releases
 
-Merging a release-preparation pull request to `main` starts the release workflow. The workflow reads the version from `CITATION.cff`, verifies the package default and Codex app-server client versions, creates the matching annotated `v*` tag when it is absent, then runs tests, signing, notarization, DMG packaging, checksum generation, and GitHub Release publication in the same run.
+The release workflow starts only when an existing `v*` tag is pushed. Ordinary pushes to `main` continue to run CI and never start a release or create a tag. A maintainer first updates `CITATION.cff`, the package default, and the Codex app-server client to the same semantic version, merges those changes, then creates and pushes the matching tag from the current `origin/main` commit.
 
-A failed run can be re-run against the same tag when it still points to the current `origin/main`. An existing GitHub Release makes later `main` runs succeed without publishing again. A tag that points to another commit fails with the conflicting SHAs visible in the log.
+The tag workflow verifies the tag name and all three version sources, and requires the tag commit and checked-out commit to equal current `origin/main`. If a GitHub Release already exists for that tag, the run succeeds without rebuilding or publishing. Otherwise the GitHub runner executes the tests, Developer ID signing, Apple notarization and stapling, DMG packaging, SHA-256 generation, and `gh release create --latest --verify-tag`. A mismatched tag or commit fails with the conflicting values visible in the log.
 
 ### Project map
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -123,7 +123,7 @@ OpenAI 官方账号切换功能当前适用于 ChatGPT 网页端，并且[尚未
 | 项目 | 状态 |
 | --- | --- |
 | Apple Silicon 版本 | 已在 [v0.1.5](https://github.com/liuzhao1225/codex-account-switcher/releases/tag/v0.1.5) 提供 |
-| 自动化 | PR CI 运行检查；准备好的版本合并到 `main` 后自动创建 tag 并发布签名版本 |
+| 自动化 | PR 和 `main` CI 运行检查；推送匹配的 `v*` tag 后发布签名版本 |
 | 代码签名 | Developer ID Application |
 | Apple 公证 | 应用和 DMG 均已公证并附加票据 |
 | 分发容器 | DMG 和 SHA-256 校验文件 |
@@ -151,9 +151,9 @@ swift test
 
 ### 自动发布
 
-发布准备 PR 合并到 `main` 后，release workflow 会从 `CITATION.cff` 读取版本，并校验本地打包默认版本与 Codex app-server 客户端版本。对应 annotated `v*` tag 不存在时由 Action 创建，随后在同一次运行中完成测试、签名、公证、DMG 打包、checksum 生成与 GitHub Release 发布。
+只有推送一个已经存在的 `v*` tag 才会启动 release workflow。普通 `main` push 仍会运行 CI，不会启动发布，也不会自动创建 tag。维护者需先将 `CITATION.cff`、本地打包默认版本和 Codex app-server 客户端版本更新为同一个语义化版本，合并到 `main`，再从当前 `origin/main` commit 创建并推送对应 tag。
 
-失败的 workflow 可以在同一 tag 仍指向当前 `origin/main` 时原地重新运行。GitHub Release 已存在时，后续 `main` 运行会成功结束且不重复发布。tag 指向其他提交时，日志会显示冲突 SHA 并直接失败。
+tag workflow 会校验 tag 名与三处版本，并要求 tag commit 和检出的 commit 都等于当前 `origin/main`。同 tag 的 GitHub Release 已存在时，workflow 成功结束，不重复构建或发布；Release 缺失时，GitHub runner 才会执行测试、Developer ID 签名、Apple 公证与票据附加、DMG 打包、SHA-256 生成，以及 `gh release create --latest --verify-tag`。tag 或 commit 不一致时，日志会显示冲突值并直接失败。
 
 ### 项目结构
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -180,13 +180,12 @@ no account-rename UI or model operation
 
 ## 8. Release automation checks
 
-The release workflow runs on pushes to `main` and `v*` tags under one repository-wide release concurrency group. Static validation should confirm:
+The release workflow runs only on `v*` tag pushes under one repository-wide release concurrency group. Static validation should confirm:
 
+- ordinary `main` pushes do not start the release workflow and the workflow never creates or pushes a tag;
 - `CITATION.cff`, the package default, and CodexClient declare the same semantic version;
 - the derived `RELEASE_TAG` supplies every artifact name and GitHub Release command;
-- a `main` run creates one annotated tag with the `github-actions[bot]` identity only when the tag is absent;
-- an existing tag is reusable only when its commit equals both the workflow commit and `origin/main`;
 - tag events require the event tag, repository version, checked-out commit, and `origin/main` commit to match;
 - an existing GitHub Release sets `SHOULD_RELEASE=false` and all tests, signing, notarization, packaging, and publication steps skip successfully;
-- a missing Release sets `SHOULD_RELEASE=true`, and the same `main` workflow continues through publication after pushing its tag;
+- a missing Release sets `SHOULD_RELEASE=true`, then the tag workflow runs tests, signing, notarization, packaging, checksum generation, and `gh release create --latest --verify-tag`;
 - conflicting tags and API failures stop with the original values visible.


### PR DESCRIPTION
## 变更

- release workflow 仅监听 `v*` tag push，普通 `main` push 不运行 release，也不再自动创建 tag
- tag workflow 校验 tag 名、`CITATION.cff`、打包默认版本和 CodexClient 版本
- 要求 tag commit 与检出 commit 都等于当前 `origin/main`
- 同 tag GitHub Release 已存在时成功 no-op；缺失时继续执行测试、Developer ID 签名、Apple 公证、DMG 与 checksum 打包，并通过 `gh release create --latest --verify-tag` 发布
- 同步中英文 README 与 release automation 测试口径

## 验证

- `git diff --check`
- release YAML 可解析，5 个 `run` 块全部通过 `bash -n`
- 三处版本均为 `0.1.5`，当前 tag、HEAD 与本地 `origin/main` commit 一致
- resolver 模拟：已有 Release → no-op；缺 Release → publish；错误 tag → 失败
- 本机未安装 `actionlint`
- 按任务要求未在本地运行完整 `swift test`；交由 PR CI 执行
